### PR TITLE
feat: add `base64` support

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -4,7 +4,7 @@ import time, socket, hashlib, base64, json
 
 start_time = time.time()
 hostname = socket.gethostname()
-api_version = "1.0"
+api_version = "1.1"
 
 class PrettyJSONResponse(JSONResponse):
     def render(self, content: any) -> bytes:
@@ -46,6 +46,6 @@ async def generate_hash(req: Request):
         "sha512": hashlib.sha512(text_bytes).hexdigest(),
         "blake2b": hashlib.blake2b(text_bytes).hexdigest(),
         "blake2s": hashlib.blake2s(text_bytes).hexdigest(),
-        # "base64": base64.b64encode(text_bytes).decode('utf-8')
+        "base64": base64.b64encode(text_bytes).decode('utf-8')
     }
     return hashes

--- a/test/tests.js
+++ b/test/tests.js
@@ -54,7 +54,7 @@ export default function () {
           "Contains md5 (32 hex chars)": (o) => o.hasOwnProperty("md5") && typeof o.md5 === "string" && o.md5.length === 32,
           "Contains sha1 (40 hex chars)": (o) => o.hasOwnProperty("sha1") && typeof o.sha1 === "string" && o.sha1.length === 40,
           "Contains sha256 (64 hex chars)": (o) => o.hasOwnProperty("sha256") && typeof o.sha256 === "string" && o.sha256.length === 64,
-          // "Contains base64": (o) => o.hasOwnProperty("base64") && typeof o.base64 === "string" && o.base64.length > 0,
+          "Contains base64": (o) => o.hasOwnProperty("base64") && typeof o.base64 === "string" && o.base64.length > 0,
         });
       }
     });


### PR DESCRIPTION
Support for `base64` on `POST /hash`:

Example
```
curl -d '{"text": "¡Este producto es fantástico!"}' localhost:8080/hash                                                                               
{
...
  "base64": "wqFFc3RlIHByb2R1Y3RvIGVzIGZhbnTDoXN0aWNvIQ=="
}
```