### PR TITLE
infra: Deployment strategy

### DIFF
--- a/infra/stacks/app/ecs-service-web.tf
+++ b/infra/stacks/app/ecs-service-web.tf
@@ -6,6 +6,12 @@ resource "aws_ecs_service" "web" {
   desired_count   = local.app.desired_count
   launch_type     = "FARGATE"
 
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+  deployment_maximum_percent         = 200
+
   lifecycle {
     ignore_changes = [task_definition]
   }


### PR DESCRIPTION
- The `deployment_circuit_breaker` block activates an automatic rollback if the new deployment fails its health checks
- With `maximum_percent = 200` and `minimum_healthy_percent = 100` ensure that a full healthy set of tasks is maintained while new tasks spin up