### PR TITLE
infra: Add logs

### DIFF
--- a/build/task-definition.json
+++ b/build/task-definition.json
@@ -15,6 +15,14 @@
       "environment": [],
       "mountPoints": [],
       "volumesFrom": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/app-cd-on-fargate-web",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "app"
+        }
+      },
       "healthCheck": {
         "command": [
           "CMD-SHELL",

--- a/infra/stacks/app/ecs-service-web.tf
+++ b/infra/stacks/app/ecs-service-web.tf
@@ -44,9 +44,22 @@ resource "aws_ecs_task_definition" "app_web" {
         retries     = 5
         startPeriod = 2
       }
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = "/ecs/${local.app.name}-web"
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "app"
+        }
+      }
       portMappings = [
         { containerPort = 8080, hostPort = 8080 }
       ]
     }
   ])
+}
+
+resource "aws_cloudwatch_log_group" "ecs" {
+  name              = "/ecs/${local.app.name}-web"
+  retention_in_days = 1
 }


### PR DESCRIPTION
Container logs with minimal configuration.

```
aws logs tail /ecs/app-cd-on-fargate-web --follow --since 10m
```

And [Cloudwatch](https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/tf-dev/services/app-cd-on-fargate-web/logs?region=us-east-1)